### PR TITLE
remove Todo from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.24 - ?
 
+- remove a todo from the docs
 
 ## v0.4.23 - 2023-12-08
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -50,8 +50,6 @@ def apt_dependencies(config_model, resource_model):
 class AptPackage(ResourceHandler):
     """
     A Package handler that uses apt
-
-    TODO: add latest support
     """
 
     def __init__(self, agent, io=None):


### PR DESCRIPTION
# Description

remove a Todo from the docs

follow up issue: https://app.zenhub.com/workspaces/core-5a7c152b04a1652024289b7b/issues/gh/inmanta/apt/281
part of https://github.com/inmanta/inmanta-core/issues/7134

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)



1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

